### PR TITLE
fix: Deploy venom-src as main site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,9 +34,11 @@ jobs:
         run: npm run build
       - name: Assemble site artifact
         run: |
-          mkdir -p _site/venom
-          cp -R docs/* _site/ || true
-          cp -R venom-src/dist/* _site/venom/
+          mkdir -p _site
+          # Use venom-src as the main site
+          cp -R venom-src/dist/* _site/
+          # Copy CNAME for custom domain
+          cp docs/CNAME _site/ || true
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:


### PR DESCRIPTION
## Summary
- Fixed deployment workflow that was putting venom-src under /venom/ while serving old site at root
- CSS/JS were returning 503 because Astro generated /_astro/ paths but files were at /venom/_astro/
- Now venom-src build is deployed at root, replacing the old site

## Root Cause
The workflow was copying old docs/* to _site/ (root) and venom-src/dist/* to _site/venom/. This meant HTML at /venom/ referenced /_astro/*.css but those files did not exist at root level.

## Fix
Deploy venom-src/dist/* directly to _site/ (root) and only copy CNAME from docs.