### PR TITLE
Fix mobile preview aspect ratio and improve touch UX

### DIFF
--- a/venom-src/src/pages/venom/demo.astro
+++ b/venom-src/src/pages/venom/demo.astro
@@ -67,11 +67,7 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
       </Card>
 
       <!-- Screenshot Panels -->
-      <div class="swipe-hint">
-        <span>← Swipe to compare →</span>
-      </div>
-
-      <div class="panels-container">
+      <div class="panels-container" id="panels-container">
         <!-- Original -->
         <Card class="panel-card">
           <h3 class="panel-title">
@@ -95,6 +91,12 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
           </div>
           <div id="poisoned-stats" class="panel-stats"></div>
         </Card>
+      </div>
+
+      <!-- Scroll Indicator (touch devices only) -->
+      <div class="scroll-indicator" id="scroll-indicator" aria-hidden="true">
+        <button class="scroll-dot active" data-index="0" aria-label="View original"></button>
+        <button class="scroll-dot" data-index="1" aria-label="View VENOM preview"></button>
       </div>
 
       <!-- Quick Examples -->
@@ -236,25 +238,12 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
   }
 
   /* Panels */
-  .swipe-hint {
-    text-align: center;
-    font-size: 12px;
-    color: var(--color-text-muted);
-    margin-bottom: var(--space-sm);
-    opacity: 0.6;
-  }
-
-  @media (min-width: 1024px) {
-    .swipe-hint {
-      display: none;
-    }
-  }
-
   .panels-container {
     display: flex;
     gap: var(--space-md);
-    margin-bottom: var(--space-xl);
+    margin-bottom: var(--space-sm);
     overflow-x: auto;
+    overflow-y: hidden;
     scroll-snap-type: x mandatory;
     scroll-behavior: smooth;
     padding-bottom: var(--space-sm);
@@ -262,6 +251,15 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
     margin-right: calc(-1 * var(--container-padding));
     padding-left: var(--container-padding);
     padding-right: var(--container-padding);
+    /* Hide scrollbar but keep functionality */
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    /* Smooth momentum scrolling on iOS */
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .panels-container::-webkit-scrollbar {
+    display: none;
   }
 
   @media (min-width: 1024px) {
@@ -273,14 +271,22 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
       margin-right: 0;
       padding-left: 0;
       padding-right: 0;
+      margin-bottom: var(--space-xl);
     }
   }
 
   .panel-card {
-    min-width: 85vw;
-    width: 85vw;
+    min-width: 92vw;
+    width: 92vw;
     flex-shrink: 0;
     scroll-snap-align: center;
+  }
+
+  @media (min-width: 480px) {
+    .panel-card {
+      min-width: 85vw;
+      width: 85vw;
+    }
   }
 
   @media (min-width: 640px) {
@@ -322,7 +328,7 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
   }
 
   .panel-preview {
-    aspect-ratio: 16 / 9;
+    aspect-ratio: var(--preview-aspect-ratio, 16 / 9);
     background: rgba(15, 20, 27, 0.5);
     border-radius: var(--radius-md);
     display: flex;
@@ -331,6 +337,7 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
     color: var(--color-text-muted);
     font-size: 14px;
     overflow: hidden;
+    transition: aspect-ratio 0.3s ease;
   }
 
   .panel-preview :global(img) {
@@ -343,6 +350,68 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
     font-size: 12px;
     color: var(--color-text-muted);
     margin-top: var(--space-sm);
+  }
+
+  /* Scroll Indicator - only visible on touch devices at smaller screens */
+  .scroll-indicator {
+    display: none;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: var(--space-lg);
+    opacity: 1;
+    transition: opacity 0.3s ease;
+  }
+
+  .scroll-indicator.hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  /* Show only on touch/coarse pointer devices below desktop breakpoint */
+  @media (max-width: 1023px) and (hover: none), (max-width: 1023px) and (pointer: coarse) {
+    .scroll-indicator {
+      display: flex;
+    }
+  }
+
+  .scroll-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    border: none;
+    background: var(--color-border);
+    cursor: pointer;
+    padding: 0;
+    transition: all 0.2s ease;
+  }
+
+  .scroll-dot:hover {
+    background: var(--color-text-muted);
+  }
+
+  .scroll-dot.active {
+    background: var(--color-text);
+    transform: scale(1.25);
+  }
+
+  /* Pulse animation on first load to draw attention */
+  .scroll-indicator.pulse .scroll-dot {
+    animation: dot-pulse 1.5s ease-in-out 2;
+  }
+
+  .scroll-indicator.pulse .scroll-dot:nth-child(2) {
+    animation-delay: 0.15s;
+  }
+
+  @keyframes dot-pulse {
+    0%, 100% { transform: scale(1); opacity: 0.5; }
+    50% { transform: scale(1.3); opacity: 1; }
+  }
+
+  .scroll-indicator.pulse .scroll-dot.active {
+    animation: none;
+    transform: scale(1.25);
+    opacity: 1;
   }
 
   /* Examples */
@@ -475,8 +544,20 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
   const lightbox = document.getElementById('lightbox') as HTMLDivElement;
   const lightboxImg = document.getElementById('lightbox-img') as HTMLImageElement;
   const lightboxClose = document.querySelector('.lightbox-close') as HTMLButtonElement;
+  const panelsContainer = document.getElementById('panels-container') as HTMLDivElement;
+  const scrollIndicator = document.getElementById('scroll-indicator') as HTMLDivElement;
+  const scrollDots = document.querySelectorAll('.scroll-dot') as NodeListOf<HTMLButtonElement>;
 
   let abortController: AbortController | null = null;
+  let hasUserScrolled = false;
+
+  // Update aspect ratio based on device selection
+  function updateAspectRatio() {
+    const mode = deviceSelect.value;
+    // Desktop: 1280x720 = 16:9, Mobile: 390x844 ≈ 9:19
+    const aspectRatio = mode === 'mobile' ? '390 / 844' : '16 / 9';
+    document.documentElement.style.setProperty('--preview-aspect-ratio', aspectRatio);
+  }
 
   function showLoading(panel: HTMLDivElement) {
     panel.innerHTML = `
@@ -597,6 +678,9 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
     if (e.key === 'Enter') loadPreview();
   });
 
+  // Update aspect ratio when device changes
+  deviceSelect.addEventListener('change', updateAspectRatio);
+
   // Example buttons
   document.querySelectorAll('.example-btn').forEach(btn => {
     btn.addEventListener('click', () => {
@@ -605,6 +689,48 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
     });
   });
 
-  // Auto-load on page load
+  // Scroll indicator functionality
+  function updateScrollIndicator() {
+    const scrollLeft = panelsContainer.scrollLeft;
+    const scrollWidth = panelsContainer.scrollWidth - panelsContainer.clientWidth;
+    const progress = scrollWidth > 0 ? scrollLeft / scrollWidth : 0;
+
+    // Determine which panel is more visible (0 = original, 1 = poisoned)
+    const activeIndex = progress > 0.5 ? 1 : 0;
+
+    scrollDots.forEach((dot, index) => {
+      dot.classList.toggle('active', index === activeIndex);
+    });
+  }
+
+  // Handle scroll on panels container
+  panelsContainer.addEventListener('scroll', () => {
+    updateScrollIndicator();
+
+    // After first user scroll, remove pulse and eventually hide
+    if (!hasUserScrolled) {
+      hasUserScrolled = true;
+      scrollIndicator.classList.remove('pulse');
+    }
+  }, { passive: true });
+
+  // Click on dots to scroll to panel
+  scrollDots.forEach((dot) => {
+    dot.addEventListener('click', () => {
+      const index = parseInt(dot.dataset.index || '0', 10);
+      const panels = panelsContainer.querySelectorAll('.panel-card');
+      if (panels[index]) {
+        panels[index].scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+      }
+    });
+  });
+
+  // Add pulse animation on load (only on touch devices)
+  if (window.matchMedia('(hover: none), (pointer: coarse)').matches) {
+    scrollIndicator.classList.add('pulse');
+  }
+
+  // Initialize aspect ratio and auto-load on page load
+  updateAspectRatio();
   loadPreview();
 </script>


### PR DESCRIPTION
## Summary
- Dynamic aspect ratio for preview panels based on device selection (16:9 for desktop, 390:844 for mobile)
- Replace text "Swipe to compare" hint with scroll indicator dots that only appear on touch devices
- Improved mobile scrolling experience with hidden scrollbar and iOS momentum scrolling
- Interactive dots allow tap navigation between panels

## Test plan
- [ ] Select "Mobile" device and verify preview boxes expand to match the taller aspect ratio
- [ ] On a touch device (or emulated), verify scroll dots appear below the panels
- [ ] Verify dots update when swiping between panels
- [ ] Verify tapping dots scrolls to the corresponding panel
- [ ] On desktop, verify scroll dots do not appear
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)