### PR TITLE
Fix mobile nav overlay showing opaque header background

### DIFF
--- a/venom-src/src/components/Header.astro
+++ b/venom-src/src/components/Header.astro
@@ -194,18 +194,29 @@ function isActive(href: string, current: string): boolean {
       padding: 14px 32px;
       font-size: 16px;
     }
+
+    /* Make header transparent when menu is open so it doesn't show through */
+    .header:has(.nav.open),
+    .header.menu-open {
+      background: transparent;
+      backdrop-filter: none;
+      -webkit-backdrop-filter: none;
+      border-bottom-color: transparent;
+    }
   }
 </style>
 
 <script>
   const toggle = document.getElementById('mobile-menu-toggle');
   const nav = document.getElementById('nav');
+  const header = document.querySelector('.header');
 
-  if (toggle && nav) {
+  if (toggle && nav && header) {
     toggle.addEventListener('click', () => {
       const isOpen = toggle.getAttribute('aria-expanded') === 'true';
       toggle.setAttribute('aria-expanded', String(!isOpen));
       nav.classList.toggle('open');
+      header.classList.toggle('menu-open');
       document.body.style.overflow = isOpen ? '' : 'hidden';
     });
 
@@ -214,6 +225,7 @@ function isActive(href: string, current: string): boolean {
       link.addEventListener('click', () => {
         toggle.setAttribute('aria-expanded', 'false');
         nav.classList.remove('open');
+        header.classList.remove('menu-open');
         document.body.style.overflow = '';
       });
     });


### PR DESCRIPTION
## Summary
- When the mobile hamburger menu is open, the header's semi-transparent background and blur effect no longer shows through
- Header becomes fully transparent when menu overlay is active

## Test plan
- [ ] On mobile (< 768px), tap hamburger menu
- [ ] Verify the header area blends seamlessly with the full-screen nav overlay
- [ ] Verify no opaque background strip visible at top when menu is open
- [ ] Verify header returns to normal appearance when menu is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)