### PR TITLE
Fix aspect ratio to only update on Load Preview click

### DIFF
--- a/venom-src/src/pages/venom/demo.astro
+++ b/venom-src/src/pages/venom/demo.astro
@@ -825,6 +825,9 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
       return;
     }
 
+    // Update aspect ratio based on device selection when loading
+    updateAspectRatio();
+
     // Abort any ongoing request
     if (abortController) {
       abortController.abort();
@@ -963,9 +966,6 @@ const description = 'See how VENOM transforms content for AI crawlers while pres
   urlInput.addEventListener('keydown', (e) => {
     if (e.key === 'Enter') loadPreview();
   });
-
-  // Update aspect ratio when device changes
-  deviceSelect.addEventListener('change', updateAspectRatio);
 
   // Example buttons
   document.querySelectorAll('.example-btn').forEach(btn => {


### PR DESCRIPTION
## Summary
- Remove `deviceSelect.addEventListener('change', updateAspectRatio)` so the preview panel aspect ratio doesn't change when switching between Desktop/Mobile in the dropdown
- Add `updateAspectRatio()` call inside `loadPreview()` so aspect ratio updates only when the Load Preview button is clicked
- This makes the UX more predictable - users won't see the panels resize unexpectedly

## Test plan
- [ ] Select Desktop device, load a preview
- [ ] Switch dropdown to Mobile - panel should NOT resize yet
- [ ] Click Load Preview - panel should resize to mobile aspect ratio
- [ ] Verify works for both directions (desktop→mobile and mobile→desktop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)