### PR TITLE
Add CDT roundtable slide deck

### DIFF
--- a/docs/slides/cdt/index.html
+++ b/docs/slides/cdt/index.html
@@ -1,0 +1,534 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Anti-Scraping Countermeasures &amp; Circumventions</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  :root {
+    --blue: #0a4d8c;
+    --blue-light: #e8f0f8;
+    --gold: #c8980a;
+    --gold-light: #fdf6e3;
+    --green: #1a7a3a;
+    --green-light: #eaf5ee;
+    --text: #1a1a1a;
+    --muted: #666;
+    --bg: #fff;
+  }
+
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: var(--text);
+    background: #111;
+    overflow: hidden;
+  }
+
+  .slide {
+    display: none;
+    width: 100vw;
+    height: 100vh;
+    background: var(--bg);
+    padding: 60px 80px;
+    flex-direction: column;
+    justify-content: center;
+    position: relative;
+  }
+
+  .slide.active { display: flex; }
+
+  .slide-number {
+    position: absolute;
+    bottom: 24px;
+    right: 40px;
+    font-size: 14px;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .slide-title {
+    font-size: 2.4em;
+    font-weight: 700;
+    color: var(--blue);
+    margin-bottom: 0.6em;
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+  }
+
+  .slide-subtitle {
+    font-size: 1.1em;
+    color: var(--muted);
+    margin-bottom: 1.5em;
+    font-weight: 400;
+  }
+
+  .slide p, .slide li {
+    font-size: 1.15em;
+    line-height: 1.6;
+    margin-bottom: 0.5em;
+  }
+
+  .slide ul { padding-left: 1.4em; margin-bottom: 0.8em; }
+  .slide li { margin-bottom: 0.3em; }
+
+  /* Tables */
+  .slide table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.95em;
+    margin: 0.8em 0;
+  }
+  .slide th, .slide td {
+    padding: 10px 14px;
+    text-align: left;
+    border-bottom: 1px solid #e0e0e0;
+  }
+  .slide th {
+    font-weight: 600;
+    color: var(--blue);
+    border-bottom: 2px solid var(--blue);
+    font-size: 0.85em;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+  .slide tr:last-child td { border-bottom: none; }
+  .slide tr.highlight { background: var(--green-light); }
+  .slide tr.highlight td { font-style: italic; color: var(--green); font-weight: 500; }
+
+  /* Tags */
+  .tag {
+    display: inline-block;
+    font-size: 0.7em;
+    padding: 3px 10px;
+    border-radius: 4px;
+    font-weight: 700;
+    letter-spacing: 0.03em;
+    vertical-align: middle;
+    margin-right: 4px;
+  }
+  .tag-ops { background: #fff3cd; color: #7a6800; }
+  .tag-ip { background: #d4edda; color: #155724; }
+
+  /* Callout boxes */
+  .callout {
+    padding: 20px 24px;
+    border-radius: 8px;
+    margin: 1em 0;
+  }
+  .callout-dual {
+    background: var(--green-light);
+    border-left: 4px solid var(--green);
+  }
+  .callout-econ {
+    background: var(--blue-light);
+    border-left: 4px solid var(--blue);
+  }
+  .callout p { font-size: 1.05em; margin-bottom: 0.4em; }
+  .callout p:last-child { margin-bottom: 0; }
+
+  /* Archetype cards */
+  .archetypes {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 20px;
+    margin-top: 0.5em;
+  }
+  .arch-card {
+    background: #fafafa;
+    border-radius: 8px;
+    padding: 20px;
+    border-top: 4px solid var(--blue);
+  }
+  .arch-card h3 {
+    font-size: 1em;
+    color: var(--blue);
+    margin-bottom: 0.5em;
+  }
+  .arch-card p {
+    font-size: 0.9em;
+    line-height: 1.5;
+    margin-bottom: 0.3em;
+  }
+  .arch-card .arch-example {
+    font-size: 0.85em;
+    color: var(--muted);
+    margin-top: 0.5em;
+    padding-top: 0.5em;
+    border-top: 1px solid #e0e0e0;
+  }
+  .arch-card.ops { border-top-color: var(--gold); }
+
+  /* Punchline */
+  .punchline {
+    font-size: 1.6em;
+    font-weight: 600;
+    color: var(--blue);
+    text-align: center;
+    margin-top: 1.2em;
+    line-height: 1.4;
+  }
+
+  /* Three paths */
+  .paths {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 20px;
+    margin: 1em 0;
+  }
+  .path-card {
+    padding: 20px;
+    border-radius: 8px;
+    background: #fafafa;
+    border-top: 4px solid #ccc;
+  }
+  .path-card h3 {
+    font-size: 1em;
+    margin-bottom: 0.5em;
+  }
+  .path-card p {
+    font-size: 0.9em;
+    line-height: 1.5;
+    margin-bottom: 0.3em;
+  }
+  .path-card .path-problem {
+    font-size: 0.85em;
+    color: var(--muted);
+    font-style: italic;
+    margin-top: 0.5em;
+  }
+  .path-card.path-std { border-top-color: var(--blue); }
+  .path-card.path-law { border-top-color: var(--gold); }
+  .path-card.path-tech { border-top-color: var(--green); }
+
+  /* Asymmetry two-column */
+  .asym-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 24px;
+    margin: 1em 0;
+  }
+  .asym-col { padding: 20px; border-radius: 8px; }
+  .asym-can { background: var(--green-light); }
+  .asym-cant { background: #fde8e8; }
+  .asym-col h3 { font-size: 1em; margin-bottom: 0.5em; }
+  .asym-col li { font-size: 0.95em; }
+
+  /* Legal list */
+  .legal-cases {
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    margin: 0.6em 0;
+  }
+  .case-chip {
+    background: var(--blue-light);
+    padding: 6px 14px;
+    border-radius: 20px;
+    font-size: 0.85em;
+    color: var(--blue);
+    font-weight: 500;
+  }
+
+  /* Emerging tools */
+  .tools-row {
+    display: flex;
+    gap: 16px;
+    margin: 0.8em 0;
+    flex-wrap: wrap;
+  }
+  .tool-chip {
+    background: var(--gold-light);
+    border: 1px solid #e8d78a;
+    padding: 8px 16px;
+    border-radius: 8px;
+    font-size: 0.9em;
+  }
+  .tool-chip strong { color: var(--gold); }
+
+  /* Speaker notes overlay */
+  .speaker-notes {
+    display: none;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: rgba(0,0,0,0.92);
+    color: #ddd;
+    padding: 16px 40px;
+    font-size: 14px;
+    line-height: 1.5;
+    max-height: 30vh;
+    overflow-y: auto;
+    z-index: 100;
+  }
+  .speaker-notes.visible { display: block; }
+
+  /* Title slide special */
+  .title-slide {
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+  }
+  .title-slide .slide-title {
+    font-size: 2.8em;
+    margin-bottom: 0.3em;
+  }
+
+  /* Controls hint */
+  .controls {
+    position: fixed;
+    bottom: 24px;
+    left: 40px;
+    font-size: 12px;
+    color: #999;
+    z-index: 50;
+  }
+
+  /* Ratio highlight */
+  .ratio-table td:nth-child(2) {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+  }
+
+  strong { font-weight: 600; }
+  .text-blue { color: var(--blue); }
+  .text-green { color: var(--green); }
+  .text-gold { color: var(--gold); }
+  .text-muted { color: var(--muted); }
+  .mt { margin-top: 0.8em; }
+  .small { font-size: 0.85em; }
+</style>
+</head>
+<body>
+
+<!-- SLIDE 0: Title -->
+<div class="slide title-slide active" data-notes="5 minutes. Chatham House Rule. Technical but accessible to policy audience.">
+  <div class="slide-title">Anti-Scraping Countermeasures<br>&amp; Circumventions</div>
+  <div class="slide-subtitle">
+    CDT Private Roundtable: Preserving an Open Internet in the AI Age<br>
+    Nick Sullivan &middot; February 10, 2026
+  </div>
+  <div class="slide-number">0 / 5</div>
+</div>
+
+<!-- SLIDE 1: The Old Deal -->
+<div class="slide" data-notes="Let the 500,000:1 number land. Pause one beat. Close with: the defenses are different. [Transition to slide 2]">
+  <div class="slide-title">The Old Deal Is Breaking Down</div>
+
+  <p>Crawlers consumed bandwidth. In return, they sent traffic back.<br>Publishers ate the cost because the return was worth it.</p>
+
+  <p class="mt"><strong>AI crawlers broke that deal.</strong></p>
+
+  <table class="ratio-table mt">
+    <tr><th>Crawler</th><th>Peak crawl-to-referral ratio (2025)</th><th></th></tr>
+    <tr><td>OpenAI</td><td>3,700 : 1</td><td class="text-muted small">3,700 pages fetched per visit sent back</td></tr>
+    <tr><td>Anthropic</td><td>500,000 : 1</td><td class="text-muted small">Half a million pages per referral</td></tr>
+  </table>
+  <p class="small text-muted">Cloudflare, Jan-Jul 2025. iFixit: 1M hits/day from Anthropic. Freelancer.com: 3.5M requests in 4 hours.</p>
+
+  <div class="callout callout-dual mt">
+    <p><span class="tag tag-ops">OPERATIONAL COST</span> Bandwidth, server strain, infrastructure burden</p>
+    <p><span class="tag tag-ip">IP EXTRACTION</span> Content in training data without permission or compensation</p>
+    <p class="small text-muted" style="margin-top:0.4em">A hobbyist forum cares about staying online. A news publisher cares about its journalism training a competitor. Not every site cares about both.</p>
+  </div>
+
+  <div class="slide-number">1 / 5</div>
+</div>
+
+<!-- SLIDE 2: Arms Race -->
+<div class="slide" data-notes="Open: What can you do if you don't want to be crawled? Walk the table top to bottom quickly: robots.txt free to ignore, all the way up to behavioral analysis. Land on last row: your servers never see a request. Blocking can't touch it.">
+  <div class="slide-title">Defenses vs. Circumventions</div>
+
+  <table>
+    <tr><th>Defense</th><th>Circumvention</th><th>Cost</th></tr>
+    <tr><td>robots.txt</td><td>Ignore it (only 30.7% of bots comply with disallow-all)</td><td>Free</td></tr>
+    <tr><td>IP blocking</td><td>Residential proxy rotation (190M IPs, $10-15/GB)</td><td>Low</td></tr>
+    <tr><td>Rate limiting</td><td>Distributed server-swarms</td><td>Low</td></tr>
+    <tr><td>CAPTCHAs</td><td>Solving services ($1-3 per 1,000)</td><td>Low</td></tr>
+    <tr><td>User-agent checks</td><td>Browser impersonation</td><td>Low</td></tr>
+    <tr><td>JS challenges</td><td>Headless browsers (Google's SearchGuard: "millions of dollars")</td><td>Med</td></tr>
+    <tr><td>Fingerprinting</td><td>Anti-detect browser frameworks</td><td>Med</td></tr>
+    <tr><td>Behavioral analysis</td><td>Human-like timing, mouse simulation</td><td>High</td></tr>
+    <tr class="highlight"><td>All of the above</td><td>Scrape from Google's cache instead of the site itself</td><td>Med</td></tr>
+  </table>
+
+  <p class="mt small"><span class="tag tag-ops">Rows 1-8</span> address <strong>operational cost</strong>. <span class="tag tag-ip">Row 9</span> is the <strong>IP problem</strong>: content extracted without touching your servers.</p>
+
+  <div class="slide-number">2 / 5</div>
+</div>
+
+<!-- SLIDE 3: Three Archetypes -->
+<div class="slide" data-notes="Expand the Perplexity story: residential proxies, spoofed fingerprints, tens of thousands of IPs. When Reddit blocked them, scraped Google's results instead. Reddit caught them with a honeypot: a post only Google could index, surfaced within hours. 'The digital equivalent of a marked bill.' [Pause.] Close: most defenses only catch category 2. Categories 1 and 3 need different approaches entirely.">
+  <div class="slide-title">Not All Scrapers Are the Same</div>
+
+  <div class="archetypes">
+    <div class="arch-card">
+      <h3>1. Compliant</h3>
+      <p>Registers user-agent, follows robots.txt, respects rate limits and HTTP error codes</p>
+      <p>High velocity, lowest cost</p>
+      <p><span class="tag tag-ip">IP extraction</span></p>
+      <div class="arch-example"><strong>Googlebot, GPTBot</strong></div>
+    </div>
+    <div class="arch-card ops">
+      <h3>2. Aggressive</h3>
+      <p>No user-agent, ignores robots.txt, brute-forces at scale</p>
+      <p>Can crash small sites (unintentional DoS)</p>
+      <p><span class="tag tag-ops">Operational cost</span></p>
+      <div class="arch-example"><strong>ByteDance Bytespider</strong><br>25x faster than GPTBot. 1.4M hits/day.</div>
+    </div>
+    <div class="arch-card">
+      <h3>3. Evasive</h3>
+      <p>Residential proxies, spoofed fingerprints, human-like timing</p>
+      <p>Low velocity, high cost ($10-15/GB)</p>
+      <p><span class="tag tag-ip">IP extraction</span></p>
+      <div class="arch-example"><strong>Perplexity</strong><br>Scraped Google's cache when blocked. Reddit caught them with a honeypot.</div>
+    </div>
+  </div>
+
+  <p class="mt">Most defenses only catch <strong>category 2</strong>. Categories 1 and 3 require different approaches.</p>
+
+  <div class="slide-number">3 / 5</div>
+</div>
+
+<!-- SLIDE 4: Tracing -->
+<div class="slide" data-notes="'But enforcement needs proof. Here's the asymmetry.' You cannot tell whether your content ended up in a training dataset. Close: these tools need to be tested in court.">
+  <div class="slide-title">Tracing Scraped Content</div>
+
+  <div class="legal-cases">
+    <span class="case-chip">Google v. SerpApi (DMCA &sect;1201, 2024)</span>
+    <span class="case-chip">Reddit v. Perplexity (DMCA + trespass, 2025)</span>
+    <span class="case-chip">LinkedIn v. Proxycurl (CFAA, 2025)</span>
+    <span class="case-chip">Copyright Office: AI training = prima facie infringement (2025)</span>
+  </div>
+
+  <p class="mt">Enforcement is possible. But it needs <strong>proof</strong>.</p>
+
+  <div class="asym-grid">
+    <div class="asym-col asym-can">
+      <h3><span class="tag tag-ops">Operational</span> Measurable today</h3>
+      <ul>
+        <li>Bot traffic volume (WAF/CDN logs)</li>
+        <li>Known crawler identification</li>
+        <li>Rate limit violations</li>
+      </ul>
+    </div>
+    <div class="asym-col asym-cant">
+      <h3><span class="tag tag-ip">IP extraction</span> Not measurable</h3>
+      <ul>
+        <li>Content in a training dataset?</li>
+        <li>Which session extracted what?</li>
+        <li>Which models used my content?</li>
+      </ul>
+    </div>
+  </div>
+
+  <div class="tools-row">
+    <span class="tool-chip"><strong>Honeypots</strong> (proven: Reddit)</span>
+    <span class="tool-chip"><strong>Watermarking</strong> (per-session fingerprints)</span>
+    <span class="tool-chip"><strong>Canary tokens</strong> (synthetic data)</span>
+    <span class="tool-chip"><strong>Membership inference</strong> (statistical tests)</span>
+  </div>
+  <p class="small text-muted">Early-stage. Need testing, refinement, and court validation.</p>
+
+  <div class="slide-number">4 / 5</div>
+</div>
+
+<!-- SLIDE 5: Three Paths -->
+<div class="slide" data-notes="Path three is where I see the most underinvestment. A decade of blocking scrapers, very little on tracking content afterward. That's the gap. You can't enforce norms or laws if you can't measure violations. [Slow down for the punchline.]">
+  <div class="slide-title">Three Paths Forward</div>
+
+  <div class="paths">
+    <div class="path-card path-std">
+      <h3 class="text-blue">Standards &amp; Norms</h3>
+      <p>Preference vocabulary (IETF AIPREF)</p>
+      <p>Cryptographic bot authentication</p>
+      <p><span class="tag tag-ops">Ops</span> <span class="tag tag-ip">IP</span></p>
+      <div class="path-problem">Voluntary. Most crawlers already ignore robots.txt.</div>
+    </div>
+    <div class="path-card path-law">
+      <h3 class="text-gold">Legal Enforcement</h3>
+      <p>DMCA &sect;1201, CFAA, contract</p>
+      <p>Case law establishing precedent</p>
+      <p><span class="tag tag-ip">IP</span></p>
+      <div class="path-problem">Expensive, slow. Needs proof that's hard to get.</div>
+    </div>
+    <div class="path-card path-tech">
+      <h3 class="text-green">Technical Measurement</h3>
+      <p>Watermarking, canaries, fingerprinting</p>
+      <p>Detect and attribute extraction</p>
+      <p><span class="tag tag-ip">IP</span></p>
+      <div class="path-problem">Nascent. Active research, not a product yet.</div>
+    </div>
+  </div>
+
+  <div class="punchline">
+    Standards for the willing.<br>
+    Law for the identifiable.<br>
+    Technology for the rest.
+  </div>
+
+  <div class="slide-number">5 / 5</div>
+</div>
+
+<!-- Speaker notes overlay -->
+<div class="speaker-notes" id="notes"></div>
+
+<!-- Controls -->
+<div class="controls" id="controls">
+  &larr; &rarr; navigate &middot; <strong>N</strong> speaker notes &middot; <strong>F</strong> fullscreen
+</div>
+
+<script>
+  const slides = document.querySelectorAll('.slide');
+  const notesEl = document.getElementById('notes');
+  let current = 0;
+  let notesVisible = false;
+
+  function showSlide(n) {
+    if (n < 0 || n >= slides.length) return;
+    slides[current].classList.remove('active');
+    current = n;
+    slides[current].classList.add('active');
+    notesEl.textContent = slides[current].dataset.notes || '';
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowRight' || e.key === ' ' || e.key === 'PageDown') {
+      e.preventDefault();
+      showSlide(current + 1);
+    } else if (e.key === 'ArrowLeft' || e.key === 'PageUp') {
+      e.preventDefault();
+      showSlide(current - 1);
+    } else if (e.key === 'n' || e.key === 'N') {
+      notesVisible = !notesVisible;
+      notesEl.classList.toggle('visible', notesVisible);
+    } else if (e.key === 'f' || e.key === 'F') {
+      if (!document.fullscreenElement) {
+        document.documentElement.requestFullscreen();
+      } else {
+        document.exitFullscreen();
+      }
+    } else if (e.key === 'Home') {
+      showSlide(0);
+    } else if (e.key === 'End') {
+      showSlide(slides.length - 1);
+    }
+  });
+
+  // Click navigation
+  document.addEventListener('click', (e) => {
+    const x = e.clientX / window.innerWidth;
+    if (x > 0.5) showSlide(current + 1);
+    else showSlide(current - 1);
+  });
+
+  // Hide controls after 3s
+  setTimeout(() => {
+    document.getElementById('controls').style.opacity = '0.3';
+  }, 3000);
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Adds HTML slide deck at /slides/cdt/ for the Feb 10 CDT roundtable presentation on anti-scraping countermeasures. Arrow keys to navigate, N for speaker notes, F for fullscreen.