### PR TITLE
Fix: include slides/ in site deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,8 +37,9 @@ jobs:
           mkdir -p _site
           # Use venom-src as the main site
           cp -R venom-src/dist/* _site/
-          # Copy CNAME for custom domain
+          # Copy static content from docs/
           cp docs/CNAME _site/ || true
+          cp -R docs/slides _site/ || true
       - name: Setup Pages
         uses: actions/configure-pages@v5
         with:


### PR DESCRIPTION
The pages workflow only copies venom-src/dist/ into the site artifact. This adds docs/slides/ so the CDT slide deck deploys to /slides/cdt/.