### PR TITLE
Remove Copyright Office references from CDT slides

### DIFF
--- a/docs/slides/cdt/index.html
+++ b/docs/slides/cdt/index.html
@@ -427,7 +427,6 @@
     <span class="case-chip">Google v. SerpApi (DMCA &sect;1201, 2024)</span>
     <span class="case-chip">Reddit v. Perplexity (DMCA + trespass, 2025)</span>
     <span class="case-chip">LinkedIn v. Proxycurl (CFAA, 2025)</span>
-    <span class="case-chip">Copyright Office: AI training = prima facie infringement (2025)</span>
   </div>
 
   <p class="mt">Enforcement is possible. But it needs <strong>proof</strong>.</p>
@@ -508,10 +507,6 @@
     <div class="faq-item">
       <div class="faq-q">How do you allowlist legitimate crawlers (Internet Archive, accessibility tools) without also allowlisting scrapers impersonating them?</div>
       <div class="faq-a">Cryptographic bot authentication (Web Bot Auth) lets crawlers prove identity with verifiable credentials, not user-agent strings. Decentralized: no single gatekeeper.</div>
-    </div>
-    <div class="faq-item">
-      <div class="faq-q">The Copyright Office opinion isn't settled law. Fair use is a four-factor balancing test. Aren't you overstating the legal landscape?</div>
-      <div class="faq-a">Fair use is a defense, not a license. Thomson Reuters won on summary judgment. But even if training is fair use, measurement tools serve transparency: publishers should know their content was used.</div>
     </div>
     <div class="faq-item">
       <div class="faq-q">Wikipedia wants to be crawled. Your framework assumes publishers want to restrict access. What about the open knowledge commons?</div>


### PR DESCRIPTION
Drop the Copyright Office prima facie infringement chip from slide 4 and the corresponding FAQ item from slide 6. Three case chips and eight FAQ items remain.