### PR TITLE
Expand Training Data Pipelines with algorithm explainers

### DIFF
--- a/docs/study/deep-dive/index.html
+++ b/docs/study/deep-dive/index.html
@@ -778,9 +778,9 @@ body {
       <h4>Anti-Detect Variants</h4>
       <p>The arms race has produced tools specifically designed to defeat the detection signals above:</p>
       <ul>
-        <li><strong><a href="https://github.com/nicegui-support/nodriver">nodriver</a></strong> — avoids CDP entirely, uses native OS-level browser control. No <code>webdriver</code> flag, no CDP artifacts. Currently the hardest headless tool to fingerprint.</li>
-        <li><strong><a href="https://github.com/ultrafunkula/undetected-chromedriver">undetected-chromedriver</a></strong> — patches Selenium's Chromedriver to remove automation signatures.</li>
-        <li><strong><a href="https://github.com/pydoll-ai/pydoll">Pydoll</a></strong> — CDP-free browser automation. New entrant (2025).</li>
+        <li><strong><a href="https://github.com/ultrafunkamsterdam/nodriver">nodriver</a></strong> — avoids CDP entirely, uses native OS-level browser control. No <code>webdriver</code> flag, no CDP artifacts. Currently the hardest headless tool to fingerprint.</li>
+        <li><strong><a href="https://github.com/ultrafunkamsterdam/undetected-chromedriver">undetected-chromedriver</a></strong> — patches Selenium's Chromedriver to remove automation signatures.</li>
+        <li><strong><a href="https://github.com/autoscrape-labs/pydoll">Pydoll</a></strong> — CDP-free browser automation. New entrant (2025).</li>
         <li><strong><a href="https://camoufox.com/">Camoufox</a></strong> — Firefox-based, exploits the fact that most anti-bot systems focus exclusively on Chromium. C++-level fingerprint injection.</li>
       </ul>
 
@@ -1303,9 +1303,9 @@ to character-level tokenization. One token becomes three.</div>
 
       <h4>Known Scraping Volumes</h4>
       <ul>
-        <li><strong>784M-1.06B Google SERPs/week</strong>: SerpApi's volume, from Google's own complaint in <a href="https://storage.courtlistener.com/recap/gov.uscourts.cand.423632/gov.uscourts.cand.423632.1.0.pdf">Google v. SerpApi</a> (December 2024). Google described the <a href="https://www.seroundtable.com/google-scraping-lawsuit-serpapi-37961.html">cost of serving these requests</a> as a significant infrastructure burden.</li>
+        <li><strong>784M-1.06B Google SERPs (Search Engine Results Pages)/week</strong>: SerpApi's volume, from Google's own complaint in <a href="https://storage.googleapis.com/gweb-uniblog-publish-prod/documents/Google_v._SerpApi__Complaint.pdf">Google v. SerpApi</a> (December 2024). Google described the <a href="https://www.seroundtable.com/google-scraping-lawsuit-serpapi-37961.html">cost of serving these requests</a> as a significant infrastructure burden.</li>
         <li><strong>Apollo.io database</strong>: ~732M unique profiles from 4.3B total records</li>
-        <li><strong>iFixit</strong>: <a href="https://twitter.com/kwiens/status/1816147902843654164">1M hits</a> from AI crawlers reported by CEO Kyle Wiens on X (July 24, 2024). <a href="https://www.404media.co/ifixit-ceo-ai-bots-scraping/">Confirmed by 404 Media</a> with server logs.</li>
+        <li><strong>iFixit</strong>: <a href="https://twitter.com/kwiens/status/1816147902843654164">1M hits</a> from AI crawlers reported by CEO Kyle Wiens on X (July 24, 2024). <a href="https://www.404media.co/anthropic-ai-scraper-hits-ifixits-website-a-million-times-in-a-day/">Confirmed by 404 Media</a> with server logs.</li>
         <li><strong>Cloudflare crawl ratios</strong> (Jan-Jul 2025, <a href="https://blog.cloudflare.com/crawlers-click-ai-bots-training/">Cloudflare blog</a>): Anthropic peaked at 500,000:1 crawl-to-click ratio. OpenAI peaked at 3,700:1.</li>
       </ul>
 
@@ -1324,7 +1324,7 @@ to character-level tokenization. One token becomes three.</div>
 
       <p><strong>Proxycurl</strong> (January 2025): Federal lawsuit. Permanent injunction. All scraped data deleted. Proxycurl shut down July 2025. At least the second such lawsuit LinkedIn filed in 2025. <a href="https://news.linkedin.com/2025/linkedin-takes-legal-action-to-defend-member-privacy">Source</a>.</p>
 
-      <p><strong>Thomson Reuters v. Ross Intelligence</strong> (2023): Thomson Reuters won on summary judgment. Ross used copyrighted Westlaw headnotes to train its legal AI. Not still litigating — decided. <a href="https://law.justia.com/cases/federal/district-courts/delaware/dedce/1:2020cv00613/73610/509/">Source</a>.</p>
+      <p><strong>Thomson Reuters v. Ross Intelligence</strong> (2023): Thomson Reuters won on summary judgment. Ross used copyrighted Westlaw headnotes to train its legal AI. Not still litigating — decided. <a href="https://www.ded.uscourts.gov/sites/ded/files/opinions/20-613_5.pdf">Source</a>.</p>
 
       <p><strong>Bright Data v. Meta and X</strong>: Bright Data won dismissals, arguing its proxy infrastructure is a neutral tool, not itself a scraping operation.</p>
 
@@ -2205,6 +2205,19 @@ Extraction: scan each space position → map codepoint to bits
 <span class="kw">&lt;noscript&gt;</span>
   <span class="kw">&lt;p&gt;</span>Meridian Castleford -- Distributed Lattice Architect<span class="kw">&lt;/p&gt;</span>
 <span class="kw">&lt;/noscript&gt;</span></div>
+
+  <h3>Why JSON-LD Is a Separate Detection Channel</h3>
+  <p>Most text extraction tools (Trafilatura, newspaper3k, readability, html2text) <strong>completely ignore</strong> <code>&lt;script type="application/ld+json"&gt;</code> blocks. They extract visible text from the DOM and discard everything else. But three major ingestion paths specifically <em>target</em> JSON-LD:</p>
+  <ol>
+    <li><strong>Knowledge graph builders</strong> (Google, Bing, Apple): parse JSON-LD to populate entity databases. A canary <code>Person</code> entity gets indexed as a real person.</li>
+    <li><strong>RAG pipelines</strong> (Perplexity, ChatGPT browse, Gemini): some extract structured data alongside text. A canary entity surfaces in retrieval-augmented answers.</li>
+    <li><strong>Schema.org harvesters</strong>: tools like Web Data Commons crawl the entire web specifically for JSON-LD/microdata. Canary entities enter these datasets independently of any text extraction.</li>
+  </ol>
+  <p>This means a canary profile injected via both CSS-hidden text <em>and</em> JSON-LD has <strong>two independent detection surfaces</strong>. Even if a scraper strips all hidden HTML (defeating the CSS channel), the JSON-LD entity enters knowledge graphs through a completely separate path. The survival matrix shows this: JSON-LD canaries are N/A for 5 of 7 text extractors because they bypass text extraction entirely.</p>
+  <div class="callout callout-green">
+    <strong>Strategic implication</strong>
+    JSON-LD injection costs almost nothing (one <code>&lt;script&gt;</code> tag per page) but opens a detection channel that no amount of text-extraction evasion can close. It's the one VENOM technique where the attacker can't defend by choosing a different extraction tool &mdash; they'd have to strip <code>&lt;script&gt;</code> tags entirely, which breaks legitimate page functionality.
+  </div>
 
   <h3>Detection System</h3>
   <div class="diagram">
@@ -3648,6 +3661,9 @@ Knowledge graph builder (Google, Perplexity):
         <dt>FineWeb</dt>
         <dd>HuggingFace&#8217;s curated web corpus (15T tokens). Uses Trafilatura for extraction plus quality classifiers. Removes ~90% of raw crawl data at quality/dedup stages.</dd>
 
+        <dt>JSON-LD (JavaScript Object Notation for Linked Data)</dt>
+        <dd>Structured data format embedded in <code>&lt;script type="application/ld+json"&gt;</code> tags. Uses schema.org vocabulary. Completely invisible to text extractors (Trafilatura, newspaper3k, etc.) but specifically targeted by knowledge graph builders (Google, Bing), RAG pipelines, and schema harvesters. VENOM injects canary Person entities via JSON-LD as an independent detection channel that bypasses all text extraction defenses (Proposal 3).</dd>
+
         <dt>KenLM</dt>
         <dd>Fast n-gram language model for perplexity scoring. Measures how &#8220;surprised&#8221; the model is by text. Low perplexity = natural language; high perplexity = gibberish. Used by FineWeb and CCNet to filter training data.</dd>
 
@@ -3699,6 +3715,9 @@ Knowledge graph builder (Google, Perplexity):
 
         <dt>Residential proxy</dt>
         <dd>IP addresses from real residential ISP connections, making bot traffic appear to come from home users. 190M IPs available (Bright Data, Oxylabs) at $10&#8211;15/GB.</dd>
+
+        <dt>SERP (Search Engine Results Page)</dt>
+        <dd>The page of results returned by a search engine for a query. Scrapers like SerpApi programmatically harvest SERPs at scale (784M&#8211;1.06B Google SERPs/week). Reddit&#8217;s honeypot proved Perplexity scraped Google SERPs to surface Reddit content.</dd>
 
         <dt>robots.txt</dt>
         <dd>30-year-old convention for declaring crawler permissions. IMC 2025 found only 30.7% compliance with disallow-all. Not technically enforceable. IETF RFC 9309 formalized the syntax.</dd>

--- a/docs/study/deep-dive/index.html
+++ b/docs/study/deep-dive/index.html
@@ -604,6 +604,7 @@ body {
   <button class="tab-btn" data-tab="p6">6. Pipeline FP <span class="badge badge-proposal">PROPOSAL</span></button>
   <button class="tab-btn" data-tab="evidence">Evidence <span class="badge badge-research">REAL</span></button>
   <button class="tab-btn" data-tab="integration">Integration Path</button>
+  <button class="tab-btn" data-tab="glossary">Glossary <span class="badge badge-research">REF</span></button>
 </div>
 
 <!-- ============================================================ -->
@@ -955,6 +956,22 @@ body {
         <li><strong><a href="https://github.com/google/sentencepiece">SentencePiece</a></strong> (Google/Meta): Used by LLaMA, Gemma, T5. Unigram or BPE mode. Operates on Unicode codepoints.</li>
       </ul>
       <p>Before tokenization, <strong>NFKC normalization</strong> (Unicode Normalization Form KC) maps compatibility-equivalent characters to their canonical form: fullwidth Latin &#8220;&#xFF21;&#8221; &#8594; &#8220;A&#8221;, math bold &#8220;&#x1D400;&#8221; &#8594; &#8220;A&#8221;, superscript &#8220;&#178;&#8221; &#8594; &#8220;2&#8221;. Critically, NFKC does <strong>not</strong> map across scripts: Cyrillic &#8220;&#1072;&#8221; (U+0430) stays Cyrillic, not Latin &#8220;a&#8221; (U+0061). This means Cyrillic and Greek homoglyphs get distinct BPE tokens from their Latin lookalikes.</p>
+
+      <h4>Worked Example: BPE Tokenization with Homoglyphs</h4>
+      <p>BPE tokenizers operate on raw byte sequences. Cyrillic characters use different UTF-8 bytes than their Latin lookalikes, so the tokenizer treats them as entirely different inputs:</p>
+      <div class="code-block"><strong>Latin "Senior"</strong>
+  UTF-8 bytes: 53 65 6E 69 6F 72
+  tiktoken:    [ "Senior" ]                          &#8594; <strong>1 token</strong>
+
+<strong>Cyrillic &#1077; substituted: "S&#1077;nior"</strong>
+  UTF-8 bytes: 53 <span style="color:#c0392b;font-weight:bold">D0 B5</span> 6E 69 6F 72
+  tiktoken:    [ "S", "<span style="color:#c0392b">&#1077;</span>", "nior" ]                  &#8594; <strong>3 tokens</strong>
+
+Latin "e" is one byte (0x65). Cyrillic "&#1077;" is two bytes (0xD0 0xB5).
+The tokenizer never learned "S&#1077;nior" as a merge &#8212; it falls back
+to character-level tokenization. One token becomes three.</div>
+
+      <p>This fragmentation is the detection mechanism. A model trained on homoglyph-watermarked text will have elevated probability for Cyrillic token IDs at positions where Latin characters normally appear &#8212; a measurable statistical signal that proves the watermarked content was in the training data.</p>
 
       <div class="callout callout-red">
         <strong>The critical bottleneck is text extraction, not tokenization.</strong>
@@ -3552,6 +3569,272 @@ Knowledge graph builder (Google, Perplexity):
   <p>LinkedIn's SSR response is 200-500ms (p50-p95). VENOM adds 0.1-0.25ms: 0.05% of p50. Below measurement noise.</p>
   <div class="tab-nav">
     <button class="tab-nav-btn" onclick="switchTab(9)"><span class="arrow">←</span> Evidence</button>
+    <button class="tab-nav-btn" onclick="switchTab(11)">Glossary <span class="arrow">→</span></button>
+  </div>
+</div>
+
+<!-- ============================================================ -->
+<!-- GLOSSARY -->
+<!-- ============================================================ -->
+<div class="panel" id="panel-glossary">
+  <h2>Glossary</h2>
+  <p>Technical terms used across all VENOM proposals. Grouped by domain.</p>
+
+  <div class="card open">
+    <div class="card-header" onclick="toggleCard(this)">
+      <h3>Unicode &amp; Text Processing</h3>
+      <span class="card-toggle">&#9660;</span>
+    </div>
+    <div class="card-body">
+      <dl>
+        <dt>BPE (Byte Pair Encoding)</dt>
+        <dd>Tokenization algorithm used by most LLMs. Learns frequent byte sequences as single tokens during training. &#8220;engineering&#8221; is one token; inserting a zero-width character splits it into multiple tokens because the byte sequence changes. Introduced by Sennrich et al. (Edinburgh, ACL 2016). Implementations: <strong>tiktoken</strong> (OpenAI, GPT-4/o1, ~100K vocab, operates on UTF-8 bytes) and <strong>SentencePiece</strong> (Google/Meta, LLaMA/Gemma/T5, operates on Unicode codepoints).</dd>
+
+        <dt>BPE fragmentation</dt>
+        <dd>Attack where invisible Unicode characters break known BPE tokens into multiple smaller tokens, inflating inference cost 1.5&#8211;3x. An invisible tax only machines pay. Basis of Proposal 5.</dd>
+
+        <dt>Bidi override (LRO/RLO)</dt>
+        <dd>Unicode characters U+202D and U+202E that force left-to-right or right-to-left text direction. Stripped by Trafilatura but survive BPE tokenization.</dd>
+
+        <dt>Confusable</dt>
+        <dd>Unicode characters from different scripts that look identical to humans. Formally tracked in Unicode TR39. Cyrillic &#8216;a&#8217; (U+0430) and Latin &#8216;a&#8217; (U+0061) are confusables. No known training lab applies TR39 filtering.</dd>
+
+        <dt>Fullwidth Latin</dt>
+        <dd>Unicode block where ASCII characters occupy CJK-width cells (e.g., fullwidth &#xFF21;). NFKC normalizes these back to standard ASCII, destroying them as watermark carriers.</dd>
+
+        <dt>Homoglyph</dt>
+        <dd>A character visually identical to another from a different Unicode script. Cyrillic &#8216;o&#8217; (U+043E) looks exactly like Latin &#8216;o&#8217; (U+006F) in web fonts but encodes to different bytes and gets a different BPE token. Basis of Proposal 1.</dd>
+
+        <dt>NFKC (Normalization Form KC)</dt>
+        <dd>Unicode normalization that decomposes then recomposes characters with compatibility mappings. Converts fullwidth Latin to ASCII. Does <strong>not</strong> normalize across scripts &#8212; Cyrillic stays Cyrillic. Applied by most BPE tokenizers as a preprocessing step.</dd>
+
+        <dt>Soft hyphen (U+00AD)</dt>
+        <dd>Invisible character suggesting a line-break opportunity. Stripped by Trafilatura (Unicode category Cf) but would survive BPE tokenization if it reached that stage.</dd>
+
+        <dt>Unicode category Cf</dt>
+        <dd>The &#8220;format&#8221; category in Unicode. Contains all invisible formatting characters: zero-width spaces, joiners, bidi overrides, soft hyphens, BOM. Trafilatura strips all Cf characters via Python&#8217;s <code>str.isprintable()</code>.</dd>
+
+        <dt>ZWSP / ZWS (U+200B)</dt>
+        <dd>Zero-Width Space. Invisible character with zero display width. Inserting it mid-word fragments BPE tokens because the byte sequence changes. Stripped by Trafilatura.</dd>
+
+        <dt>ZWNJ (U+200C)</dt>
+        <dd>Zero-Width Non-Joiner. Prevents ligature formation. Stripped by Trafilatura.</dd>
+
+        <dt>ZWJ (U+200D)</dt>
+        <dd>Zero-Width Joiner. Triggers ligature formation (also used in emoji sequences like &#x1F469;&#x200D;&#x1F4BB;). Stripped by Trafilatura.</dd>
+
+        <dt>Word Joiner (U+2060)</dt>
+        <dd>Invisible character preventing line breaks. Stripped by Trafilatura. Creates its own BPE token (2 tokens in tiktoken).</dd>
+      </dl>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header" onclick="toggleCard(this)">
+      <h3>ML / NLP Pipeline</h3>
+      <span class="card-toggle">&#9654;</span>
+    </div>
+    <div class="card-body">
+      <dl>
+        <dt>C4 (Colossal Clean Crawled Corpus)</dt>
+        <dd>Google&#8217;s filtered Common Crawl dataset (750GB). Used for training T5 and UL2. Heavy heuristic filtering removes low-quality text.</dd>
+
+        <dt>Common Crawl</dt>
+        <dd>Non-profit that crawls the web monthly: 9.5+ petabytes total, 2.4 billion pages per crawl. The base dataset for GPT-3, LLaMA, T5, and most other LLMs. Distributed as WARC files.</dd>
+
+        <dt>Deduplication (MinHash / SimHash)</dt>
+        <dd><strong>MinHash</strong>: generates fixed-size signatures from n-gram shingles; estimates Jaccard similarity via Locality-Sensitive Hashing (LSH). Threshold: &gt;0.8 similarity = duplicate. <strong>SimHash</strong>: single 64-bit fingerprint per document; Hamming distance approximates cosine similarity. Faster but less precise. <strong>Exact dedup</strong>: document-level SHA-256 hashing.</dd>
+
+        <dt>FineWeb</dt>
+        <dd>HuggingFace&#8217;s curated web corpus (15T tokens). Uses Trafilatura for extraction plus quality classifiers. Removes ~90% of raw crawl data at quality/dedup stages.</dd>
+
+        <dt>KenLM</dt>
+        <dd>Fast n-gram language model for perplexity scoring. Measures how &#8220;surprised&#8221; the model is by text. Low perplexity = natural language; high perplexity = gibberish. Used by FineWeb and CCNet to filter training data.</dd>
+
+        <dt>LSTM (Long Short-Term Memory)</dt>
+        <dd>Recurrent neural network for sequential data. LinkedIn uses LSTMs to model user action sequences and detect scraper behavior patterns. Nearly doubled detection recall for low-frequency automation (2021).</dd>
+
+        <dt>Model collapse</dt>
+        <dd>Phenomenon where models trained on AI-generated or poisoned data degrade in quality. Shumailov and Zhao (Google DeepMind, 2024) showed canary tokens in training data cause models to hallucinate canary entities.</dd>
+
+        <dt>RAG (Retrieval-Augmented Generation)</dt>
+        <dd>Architecture where an LLM retrieves external documents at inference time. Token inflation (Proposal 5) is especially effective against RAG: inflated text fills context windows 2&#8211;3x faster, degrading output quality.</dd>
+
+        <dt>Training data membership inference</dt>
+        <dd>Determining whether specific content was in a model&#8217;s training set. Methods: statistical analysis, divergence attacks (&#8220;Repeat the word X forever&#8221;), or planted watermark detection.</dd>
+
+        <dt>WARC (Web ARChive)</dt>
+        <dd>Standard file format for web crawl data. Common Crawl distributes data as WARC files containing raw HTML, HTTP headers, and metadata.</dd>
+      </dl>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header" onclick="toggleCard(this)">
+      <h3>Anti-Scraping &amp; Bot Detection</h3>
+      <span class="card-toggle">&#9654;</span>
+    </div>
+    <div class="card-body">
+      <dl>
+        <dt>Anti-detect browser</dt>
+        <dd>Software (Multilogin, GoLogin, Kameleo, Camoufox) that disguises automated scrapers as real browsers by presenting consistent, plausible fingerprints. $30&#8211;300/month.</dd>
+
+        <dt>Canary token / Canary trap</dt>
+        <dd>Synthetic data element that, when found in an external dataset or model output, proves extraction occurred. Borrowed from intelligence tradecraft: distribute slightly different versions to different recipients; when one leaks, the source is identified. VENOM applies this to web content (Proposal 3).</dd>
+
+        <dt>CDP (Chrome DevTools Protocol)</dt>
+        <dd>Debugging protocol Chrome exposes to automation tools (Puppeteer, Playwright). Leaves detectable artifacts: <code>__playwright__binding__</code> globals, <code>Error.stack</code> traps, synthetic <code>navigator.plugins</code>.</dd>
+
+        <dt>Crawl-to-referral ratio</dt>
+        <dd>Pages crawled vs. visitors sent back. Anthropic peaked at 500,000:1; OpenAI at 3,700:1; Google at 14:1 (Cloudflare, Jan&#8211;Jul 2025).</dd>
+
+        <dt>Default-deny</dt>
+        <dd>Architecture blocking all AI crawlers unless explicitly permitted. Cloudflare deployed this for CDN customers in July 2025, affecting ~20% of the web.</dd>
+
+        <dt>Honeypot</dt>
+        <dd>Deliberately placed fake content designed to attract scrapers. Reddit&#8217;s SERP honeypot proved Perplexity scraped Google results to get Reddit content (surfaced within hours).</dd>
+
+        <dt>Hydration / Hydration beacon</dt>
+        <dd><strong>Hydration</strong>: client-side JS activating server-rendered HTML. The gap between SSR delivery and hydration completion is VENOM&#8217;s injection window (Proposal 4). <strong>Beacon</strong>: lightweight <code>navigator.sendBeacon()</code> confirming JS executed; absence identifies non-JS scrapers.</dd>
+
+        <dt>Residential proxy</dt>
+        <dd>IP addresses from real residential ISP connections, making bot traffic appear to come from home users. 190M IPs available (Bright Data, Oxylabs) at $10&#8211;15/GB.</dd>
+
+        <dt>robots.txt</dt>
+        <dd>30-year-old convention for declaring crawler permissions. IMC 2025 found only 30.7% compliance with disallow-all. Not technically enforceable. IETF RFC 9309 formalized the syntax.</dd>
+
+        <dt>JA3 / JA4</dt>
+        <dd>TLS client fingerprinting methods. Hash the ClientHello parameters (cipher suites, extensions, curves). Every HTTP client has a distinct fingerprint; headless Chrome&#8217;s JA4 differs from real Chrome&#8217;s.</dd>
+
+        <dt>Tripwire</dt>
+        <dd>Hidden DOM element (off-screen link, invisible form, zero-opacity anchor) that real users never interact with but scrapers traverse. Activation confirms automated extraction.</dd>
+      </dl>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header" onclick="toggleCard(this)">
+      <h3>Cryptography &amp; Watermarking</h3>
+      <span class="card-toggle">&#9654;</span>
+    </div>
+    <div class="card-body">
+      <dl>
+        <dt>C2PA</dt>
+        <dd>Coalition for Content Provenance and Authenticity. Standard for cryptographically signed &#8220;content credentials&#8221; proving media origin and edit history. C2PA 2.1 (Oct 2024) added watermarking via Digimarc. Primarily images/video; text provenance is underdeveloped.</dd>
+
+        <dt>Divergence attack</dt>
+        <dd>Prompt technique (&#8220;Repeat the word X forever&#8221;) causing LLMs to emit raw training data. Carlini et al. extracted &gt;10,000 unique sequences from ChatGPT for $200 (ICLR 2025).</dd>
+
+        <dt>HMAC (Hash-Based Message Authentication Code)</dt>
+        <dd>Keyed hash function. VENOM uses HMAC-SHA256 to deterministically derive canary names and watermark patterns from session IDs, ensuring reversibility: name &#8594; session &#8594; scraper.</dd>
+
+        <dt>Membership inference attack (MIA)</dt>
+        <dd>ML technique for determining whether specific data was in a model&#8217;s training set. Applied to watermarked content: if the watermark pattern is detectable in outputs, the content was trained on.</dd>
+
+        <dt>Radioactive watermark</dt>
+        <dd>Watermark persisting in model weights after training. Sander et al. (Meta/FAIR, NeurIPS 2024) demonstrated detection at p &lt; 10&#8315;&#8309; with only 5% contamination of training text.</dd>
+
+        <dt>Steganography</dt>
+        <dd>Hiding information within other information. VENOM context: encoding session IDs within visible text using Unicode variations, whitespace substitution, or synonym selection.</dd>
+
+        <dt>SynthID-Text</dt>
+        <dd>Google DeepMind&#8217;s text watermarking (Nature, Oct 2024). Uses &#8220;tournament sampling&#8221; to mark AI-generated text. Marks AI output; VENOM marks scraped human text. Different use case.</dd>
+
+        <dt>Innamark</dt>
+        <dd>Kotlin/JVM watermarking library (Hellmeier et al., Fraunhofer ISST, IEEE Access 2025). Encodes binary data by substituting regular spaces with 5 visually identical Unicode whitespace characters. Evades 4 of 6 top LLMs. Basis of Proposal 2.</dd>
+      </dl>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header" onclick="toggleCard(this)">
+      <h3>LinkedIn Architecture</h3>
+      <span class="card-toggle">&#9654;</span>
+    </div>
+    <div class="card-body">
+      <dl>
+        <dt>Pemberly</dt>
+        <dd>LinkedIn&#8217;s custom frontend framework built on Ember.js with three rendering modes: vanilla CSR, SSR (via Fastboot), and BigPipe (hybrid streaming). By 2023 the codebase was 3M lines with 17-minute builds.</dd>
+
+        <dt>Fastboot / Shoebox</dt>
+        <dd><strong>Fastboot</strong>: Ember CLI add-on enabling SSR of Ember.js apps in Node.js. <strong>Shoebox</strong>: Fastboot&#8217;s mechanism for serializing server data into <code>&lt;script type=&quot;fastboot/shoebox&quot;&gt;</code> tags. VENOM injects canary entries with <code>_vn</code> keys that the client filters during rehydration.</dd>
+
+        <dt>BigPipe</dt>
+        <dd>Facebook-originated technique (2010) for streaming page content in chunks via <code>&lt;script&gt;</code> tags. LinkedIn adopted it for progressive loading. VENOM exploits chunk timing: canaries in later chunks (t&gt;300ms) catch scrapers waiting for full content.</dd>
+
+        <dt>SSR (Server-Side Rendering)</dt>
+        <dd>Rendering HTML on the server. Critical to VENOM because SSR delivers complete HTML before client JS executes, creating a controlled injection point for content that scrapers see but real users don&#8217;t.</dd>
+
+        <dt>Voyager API</dt>
+        <dd>LinkedIn&#8217;s internal API layer. Endpoints update every 4&#8211;8 weeks; frontend elements every 2&#8211;4 weeks. Scrapers targeting the API directly bypass SSR-based defenses.</dd>
+      </dl>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header" onclick="toggleCard(this)">
+      <h3>Legal &amp; Policy</h3>
+      <span class="card-toggle">&#9654;</span>
+    </div>
+    <div class="card-body">
+      <dl>
+        <dt>AIPREF</dt>
+        <dd>IETF working group developing vocabulary for websites to express AI-related preferences (training, RAG, summarization). Chartered Jan 2025, targeting Aug 2026. Explicitly excludes enforcement. Chaired by Mark Nottingham and Suresh Krishnan.</dd>
+
+        <dt>CFAA (Computer Fraud and Abuse Act)</dt>
+        <dd>Federal anti-hacking statute. Ninth Circuit ruled scraping public data doesn&#8217;t violate CFAA (hiQ v. LinkedIn). Contract-based ToS claims remain viable.</dd>
+
+        <dt>Chatham House Rule</dt>
+        <dd>Meeting protocol: participants may use information but may not attribute statements to individuals or organizations.</dd>
+
+        <dt>DMCA Section 1201</dt>
+        <dd>Anti-circumvention provision prohibiting bypassing technological protection measures. Reddit v. Perplexity and Google v. SerpApi both invoke &#167;1201 against scraping that circumvents access controls.</dd>
+
+        <dt>EU AI Act</dt>
+        <dd>EU regulation (2026 enforcement) requiring AI companies to publish dataset summaries. Penalties up to 3% of worldwide annual revenue. VENOM watermarks could serve as evidence in enforcement.</dd>
+
+        <dt>Prima facie</dt>
+        <dd>&#8220;On its face.&#8221; Evidence sufficient to establish a fact unless rebutted. U.S. Copyright Office stated (May 2025) that unauthorized AI training constitutes prima facie infringement.</dd>
+
+        <dt>RSL (Really Simple Licensing)</dt>
+        <dd>Machine-readable XML protocol for declaring content licensing terms to AI crawlers. v1.0 finalized Dec 2025. Endorsed by Cloudflare, Akamai, AP, Stack Overflow. No major AI company has committed to honoring it.</dd>
+      </dl>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header" onclick="toggleCard(this)">
+      <h3>Tools &amp; Libraries</h3>
+      <span class="card-toggle">&#9654;</span>
+    </div>
+    <div class="card-body">
+      <dl>
+        <dt>Trafilatura</dt>
+        <dd>Python text extraction library (F1=0.96). The critical bottleneck in training data pipelines. Strips all Unicode category Cf characters via <code>str.isprintable()</code>. Does NOT strip cross-script homoglyphs, <code>visibility:hidden</code>, or <code>font-size:0</code> content.</dd>
+
+        <dt>BeautifulSoup</dt>
+        <dd>Python HTML parser. <code>.get_text()</code> concatenates all text nodes with zero CSS awareness. Everything survives: <code>display:none</code>, zero-width characters, homoglyphs. Not used in serious training pipelines.</dd>
+
+        <dt>newspaper3k / newspaper4k</dt>
+        <dd>Article-focused extraction. Identifies main content, strips boilerplate. Limited CSS parsing. Homoglyphs and <code>font-size:0</code> content survive.</dd>
+
+        <dt>readability-lxml</dt>
+        <dd>Python port of Mozilla Readability (Firefox Reader View). Scores DOM nodes by text density. Content within the main article body generally survives regardless of CSS visibility.</dd>
+
+        <dt>Bright Data</dt>
+        <dd>Major residential proxy provider. 190M+ IPs. Won legal dismissals against Meta (2024) and X (2024) establishing that scraping public data while not logged in doesn&#8217;t violate ToS.</dd>
+
+        <dt>nodriver</dt>
+        <dd>Browser automation that avoids CDP entirely via native OS-level control. No <code>webdriver</code> flag, no CDP artifacts. Currently the hardest headless tool to fingerprint.</dd>
+
+        <dt>StegCloak</dt>
+        <dd>npm library for zero-width character steganography. Encodes payloads using ZWSP + ZWNJ + ZWJ. Detected by all 6 LLMs in the Innamark study &#8212; less suitable for covert watermarking than Innamark.</dd>
+      </dl>
+    </div>
+  </div>
+
+  <div class="tab-nav">
+    <button class="tab-nav-btn" onclick="switchTab(10)"><span class="arrow">&#8592;</span> Integration Path</button>
     <button class="tab-nav-btn" disabled></button>
   </div>
 </div>
@@ -3565,6 +3848,7 @@ Knowledge graph builder (Google, Perplexity):
     <div class="shortcut-row"><span>Next tab</span><span class="shortcut-key">&rarr; or swipe left</span></div>
     <div class="shortcut-row"><span>Previous tab</span><span class="shortcut-key">&larr; or swipe right</span></div>
     <div class="shortcut-row"><span>Go to tab N</span><span class="shortcut-key">1-9, 0</span></div>
+    <div class="shortcut-row"><span>Glossary</span><span class="shortcut-key">G</span></div>
     <div class="shortcut-row"><span>Toggle shortcuts</span><span class="shortcut-key">?</span></div>
     <div class="shortcut-row"><span>Close overlay</span><span class="shortcut-key">Esc</span></div>
   </div>
@@ -3624,7 +3908,7 @@ if ('serviceWorker' in navigator) {
 }
 
 // Tab navigation with touch gestures
-var tabs = ['overview','scrapers','pipeline','p1','p2','p3','p4','p5','p6','evidence','integration'];
+var tabs = ['overview','scrapers','pipeline','p1','p2','p3','p4','p5','p6','evidence','integration','glossary'];
 var currentTab = 0;
 var touchStartX = 0;
 var touchStartY = 0;
@@ -3692,6 +3976,7 @@ document.addEventListener('keydown', function(e) {
   else if (e.key === 'Escape') {
     document.getElementById('shortcutsOverlay').classList.remove('visible');
   }
+  else if (e.key === 'g' || e.key === 'G') { switchTab(tabs.indexOf('glossary')); }
   else if (e.key >= '1' && e.key <= '9') { switchTab(parseInt(e.key) - 1); }
   else if (e.key === '0') { switchTab(9); }
 });

--- a/docs/study/deep-dive/index.html
+++ b/docs/study/deep-dive/index.html
@@ -854,46 +854,112 @@ body {
       <span class="card-toggle">&#9654;</span>
     </div>
     <div class="card-body">
+      <p><a href="https://commoncrawl.org/">Common Crawl</a> is the foundation of most LLM training data: 9.5+ petabytes, 2.4 billion pages per monthly crawl, 279 million host-level nodes in the January 2026 crawl. It feeds directly or indirectly into every major open LLM through derived datasets:</p>
+
+      <div class="table-wrapper">
+      <table class="data-table">
+        <thead>
+          <tr><th>Dataset</th><th>Builder</th><th>Size</th><th>Used By</th><th>Extraction</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>C4</td><td>Google</td><td>750GB</td><td>T5, UL2</td><td>CC WET + heuristic filtering</td></tr>
+          <tr><td><a href="https://huggingface.co/datasets/HuggingFaceFW/fineweb">FineWeb</a></td><td>HuggingFace</td><td>15T tokens</td><td>SmolLM, community</td><td>Trafilatura + quality classifiers</td></tr>
+          <tr><td><a href="https://huggingface.co/datasets/tiiuae/falcon-refinedweb">RefinedWeb</a></td><td>TII (Falcon)</td><td>5T tokens</td><td>Falcon</td><td>Trafilatura + MacroData Refinement</td></tr>
+          <tr><td>CCNet</td><td>Meta</td><td>Varies</td><td>LLaMA</td><td>CC WET + fastText + perplexity</td></tr>
+          <tr><td><a href="https://pile.eleuther.ai/">The Pile</a></td><td>EleutherAI</td><td>825GB</td><td>GPT-NeoX, Pythia</td><td>22 diverse sources, curated</td></tr>
+          <tr><td><a href="https://www.datacomp.ai/">DCLM</a></td><td>DataComp</td><td>3T tokens</td><td>Benchmark suite</td><td>Quality-filtered, standardized eval</td></tr>
+          <tr><td><a href="https://www.together.ai/blog/redpajama">RedPajama</a></td><td>Together</td><td>1.2T tokens</td><td>RedPajama models</td><td>LLaMA recipe reproduction</td></tr>
+        </tbody>
+      </table>
+      </div>
+
+      <h4>The 7-Stage Pipeline</h4>
+      <p>Raw web pages go through seven stages before becoming training tokens. Each stage applies specific transformations — understanding these is critical for designing watermarks that survive.</p>
+
       <div class="diagram">
-        <svg viewBox="0 0 900 160" xmlns="http://www.w3.org/2000/svg">
+        <svg viewBox="0 0 1060 180" xmlns="http://www.w3.org/2000/svg">
           <rect x="10" y="50" width="110" height="60" rx="6" fill="#e8f0f8" stroke="#0a4d8c" stroke-width="2"/>
-          <text x="65" y="75" text-anchor="middle" font-size="11" font-weight="700" fill="#0a4d8c">Web Crawl</text>
-          <text x="65" y="92" text-anchor="middle" font-size="9" fill="#666">WARC files</text>
-          <line x1="120" y1="80" x2="160" y2="80" stroke="#0a4d8c" stroke-width="2" marker-end="url(#arrow)"/>
+          <text x="65" y="75" text-anchor="middle" font-size="10" font-weight="700" fill="#0a4d8c">1. Crawl</text>
+          <text x="65" y="90" text-anchor="middle" font-size="8" fill="#666">WARC files</text>
+          <line x1="120" y1="80" x2="150" y2="80" stroke="#0a4d8c" stroke-width="2" marker-end="url(#arrow)"/>
 
-          <rect x="160" y="50" width="120" height="60" rx="6" fill="#fde8e8" stroke="#c0392b" stroke-width="2"/>
-          <text x="220" y="75" text-anchor="middle" font-size="11" font-weight="700" fill="#c0392b">Text Extraction</text>
-          <text x="220" y="92" text-anchor="middle" font-size="9" fill="#666">Trafilatura (F1=0.96)</text>
-          <line x1="280" y1="80" x2="310" y2="80" stroke="#0a4d8c" stroke-width="2" marker-end="url(#arrow)"/>
-          <text x="295" y="40" font-size="9" fill="#c0392b" font-weight="700">GATE 1</text>
+          <rect x="150" y="50" width="110" height="60" rx="6" fill="#fde8e8" stroke="#c0392b" stroke-width="2"/>
+          <text x="205" y="75" text-anchor="middle" font-size="10" font-weight="700" fill="#c0392b">2. Extraction</text>
+          <text x="205" y="90" text-anchor="middle" font-size="8" fill="#666">Trafilatura</text>
+          <line x1="260" y1="80" x2="290" y2="80" stroke="#0a4d8c" stroke-width="2" marker-end="url(#arrow)"/>
+          <text x="275" y="40" font-size="8" fill="#c0392b" font-weight="700">GATE</text>
 
-          <rect x="310" y="50" width="110" height="60" rx="6" fill="#fdf6e3" stroke="#c8980a" stroke-width="2"/>
-          <text x="365" y="75" text-anchor="middle" font-size="11" font-weight="700" fill="#c8980a">Quality Filter</text>
-          <text x="365" y="92" text-anchor="middle" font-size="9" fill="#666">C4 / FineWeb</text>
-          <line x1="420" y1="80" x2="450" y2="80" stroke="#0a4d8c" stroke-width="2" marker-end="url(#arrow)"/>
+          <rect x="290" y="50" width="110" height="60" rx="6" fill="#e8f0f8" stroke="#0a4d8c" stroke-width="2"/>
+          <text x="345" y="75" text-anchor="middle" font-size="10" font-weight="700" fill="#0a4d8c">3. Lang ID</text>
+          <text x="345" y="90" text-anchor="middle" font-size="8" fill="#666">fastText lid.176</text>
+          <line x1="400" y1="80" x2="430" y2="80" stroke="#0a4d8c" stroke-width="2" marker-end="url(#arrow)"/>
 
-          <rect x="450" y="50" width="110" height="60" rx="6" fill="#fdf6e3" stroke="#c8980a" stroke-width="2"/>
-          <text x="505" y="75" text-anchor="middle" font-size="11" font-weight="700" fill="#c8980a">Deduplication</text>
-          <text x="505" y="92" text-anchor="middle" font-size="9" fill="#666">MinHash / exact</text>
-          <line x1="560" y1="80" x2="590" y2="80" stroke="#0a4d8c" stroke-width="2" marker-end="url(#arrow)"/>
+          <rect x="430" y="50" width="110" height="60" rx="6" fill="#fdf6e3" stroke="#c8980a" stroke-width="2"/>
+          <text x="485" y="75" text-anchor="middle" font-size="10" font-weight="700" fill="#c8980a">4. Quality</text>
+          <text x="485" y="90" text-anchor="middle" font-size="8" fill="#666">KenLM perplexity</text>
+          <line x1="540" y1="80" x2="570" y2="80" stroke="#0a4d8c" stroke-width="2" marker-end="url(#arrow)"/>
 
-          <rect x="590" y="50" width="120" height="60" rx="6" fill="#f3e8ff" stroke="#6b21a8" stroke-width="2"/>
-          <text x="650" y="75" text-anchor="middle" font-size="11" font-weight="700" fill="#6b21a8">Tokenization</text>
-          <text x="650" y="92" text-anchor="middle" font-size="9" fill="#666">BPE / SentencePiece</text>
-          <line x1="710" y1="80" x2="740" y2="80" stroke="#0a4d8c" stroke-width="2" marker-end="url(#arrow)"/>
+          <rect x="570" y="50" width="110" height="60" rx="6" fill="#fdf6e3" stroke="#c8980a" stroke-width="2"/>
+          <text x="625" y="75" text-anchor="middle" font-size="10" font-weight="700" fill="#c8980a">5. Dedup</text>
+          <text x="625" y="90" text-anchor="middle" font-size="8" fill="#666">MinHash / SimHash</text>
+          <line x1="680" y1="80" x2="710" y2="80" stroke="#0a4d8c" stroke-width="2" marker-end="url(#arrow)"/>
 
-          <rect x="740" y="50" width="110" height="60" rx="6" fill="#eaf5ee" stroke="#1a7a3a" stroke-width="2"/>
-          <text x="795" y="75" text-anchor="middle" font-size="11" font-weight="700" fill="#1a7a3a">Training</text>
-          <text x="795" y="92" text-anchor="middle" font-size="9" fill="#666">Model weights</text>
+          <rect x="710" y="50" width="110" height="60" rx="6" fill="#f3e8ff" stroke="#6b21a8" stroke-width="2"/>
+          <text x="765" y="75" text-anchor="middle" font-size="10" font-weight="700" fill="#6b21a8">6. Tokenize</text>
+          <text x="765" y="90" text-anchor="middle" font-size="8" fill="#666">BPE + NFKC</text>
+          <line x1="820" y1="80" x2="850" y2="80" stroke="#0a4d8c" stroke-width="2" marker-end="url(#arrow)"/>
 
-          <text x="220" y="140" text-anchor="middle" font-size="9" fill="#c0392b">Strips: ZWS, ZWNJ, ZWJ,</text>
-          <text x="220" y="152" text-anchor="middle" font-size="9" fill="#c0392b">bidi overrides, soft hyphens</text>
-          <text x="650" y="140" text-anchor="middle" font-size="9" fill="#6b21a8">NFKC: fullwidth-&gt;ASCII</text>
-          <text x="650" y="152" text-anchor="middle" font-size="9" fill="#1a7a3a">Preserves: homoglyphs</text>
+          <rect x="850" y="50" width="110" height="60" rx="6" fill="#eaf5ee" stroke="#1a7a3a" stroke-width="2"/>
+          <text x="905" y="75" text-anchor="middle" font-size="10" font-weight="700" fill="#1a7a3a">7. Training</text>
+          <text x="905" y="90" text-anchor="middle" font-size="8" fill="#666">Model weights</text>
+
+          <text x="205" y="140" text-anchor="middle" font-size="8" fill="#c0392b">Strips: Cf chars, whitespace,</text>
+          <text x="205" y="152" text-anchor="middle" font-size="8" fill="#c0392b">display:none, boilerplate</text>
+          <text x="625" y="140" text-anchor="middle" font-size="8" fill="#c8980a">FineWeb removes ~90%</text>
+          <text x="625" y="152" text-anchor="middle" font-size="8" fill="#c8980a">of crawl data at stages 4-5</text>
+          <text x="765" y="140" text-anchor="middle" font-size="8" fill="#6b21a8">NFKC: fullwidth&#8594;ASCII</text>
+          <text x="765" y="152" text-anchor="middle" font-size="8" fill="#6b21a8">Cyrillic/Greek preserved</text>
         </svg>
       </div>
-      <p>The critical bottleneck is <strong>text extraction</strong>, not tokenization. Trafilatura uses Python's <code>str.isprintable()</code> filter, which strips all Unicode category Cf (format) characters. Everything that passes extraction is faithfully preserved by BPE tokenizers.</p>
-      <p><strong>Key finding</strong>: Cross-script homoglyphs (Cyrillic, Greek) survive the entire pipeline. They are printable, pass NFKC normalization, and get distinct tokens in BPE vocabularies. This is the basis for Proposal 1.</p>
+
+      <h4>Stage 2: Text Extraction &#8212; The Critical Gate</h4>
+      <p><a href="https://trafilatura.readthedocs.io/">Trafilatura</a> (<a href="https://trafilatura.readthedocs.io/en/latest/evaluation.html">F1=0.96</a> on the GoldStandard benchmark) converts raw HTML to clean text. Its key filter is Python's <code>str.isprintable()</code>, which returns <code>False</code> for any character in Unicode category <strong>Cf</strong> (format characters). This strips:</p>
+      <ul>
+        <li><strong>Zero-width space</strong> (U+200B), <strong>ZWNJ</strong> (U+200C), <strong>ZWJ</strong> (U+200D)</li>
+        <li><strong>Soft hyphens</strong> (U+00AD), <strong>word joiners</strong> (U+2060), <strong>BOM</strong> (U+FEFF)</li>
+        <li><strong>Bidi overrides</strong> (U+202A&#8211;U+202E) used for right-to-left text spoofing</li>
+      </ul>
+      <p>Separately, Trafilatura uses XPath queries to strip <code>display:none</code> elements and boilerplate (nav, footer, sidebar). It does <strong>not</strong> strip <code>visibility:hidden</code>, <code>font-size:0</code>, or <code>opacity:0</code> content &#8212; it has no CSS computation engine. This is the single stage where most VENOM techniques survive or die.</p>
+
+      <h4>Stage 3: Language Detection</h4>
+      <p><a href="https://fasttext.cc/docs/en/language-identification.html">fastText lid.176</a> classifies text into 176 languages using character n-gram embeddings. It operates on sequences of 2&#8211;6 characters, computing a probability distribution over languages. Cyrillic homoglyphs in English text (Cyrillic &#8220;&#1072;&#8221; replacing Latin &#8220;a&#8221;) don't trigger misclassification: the substitution rate (~0.1 bits/character) is far below what's needed to shift the overall language distribution.</p>
+
+      <h4>Stage 4: Quality Filtering &#8212; KenLM Perplexity</h4>
+      <p><a href="https://kheafield.com/code/kenlm/">KenLM</a> is a fast n-gram language model that scores how &#8220;surprised&#8221; it is by a text sequence. <strong>Perplexity</strong> measures this: low perplexity = text looks like natural language, high perplexity = gibberish, machine-generated, or degenerate. FineWeb trains a KenLM 5-gram model on Wikipedia, then discards documents above a perplexity threshold.</p>
+      <p>Additional heuristic rules discard documents that are too short, too repetitive (character-level or line-level), or have excessive symbols. Combined with quality classifiers (trained on curated data), these filters discard roughly 90% of raw crawl data.</p>
+      <p>VENOM canary profiles survive because they are syntactically and semantically valid text &#8212; they read like real profile descriptions and score low perplexity.</p>
+
+      <h4>Stage 5: Deduplication &#8212; MinHash and SimHash</h4>
+      <p>Two algorithms remove near-identical documents from the corpus:</p>
+      <ul>
+        <li><strong>MinHash</strong>: Generates a fixed-size signature by hashing character n-gram shingles and keeping the minimum hash value per permutation. Two documents' <a href="https://en.wikipedia.org/wiki/Jaccard_index">Jaccard similarity</a> is estimated by comparing how many signature elements match. <strong>Locality-Sensitive Hashing (LSH)</strong> groups candidates into buckets so only plausible duplicates are compared pairwise. Typical threshold: documents with &gt;0.8 Jaccard similarity are flagged as duplicates.</li>
+        <li><strong>SimHash</strong>: Generates a single 64-bit fingerprint per document. The <a href="https://en.wikipedia.org/wiki/Hamming_distance">Hamming distance</a> between fingerprints approximates cosine similarity. Faster than MinHash but less precise.</li>
+        <li><strong>Exact dedup</strong>: Document-level hashing (SHA-256 or similar). Catches identical copies only.</li>
+      </ul>
+      <p>VENOM watermarks survive dedup because each session's pattern is unique &#8212; two scrapes of the same profile produce different homoglyph substitutions, different hashes, and different MinHash signatures.</p>
+
+      <h4>Stage 6: Tokenization &#8212; BPE and NFKC</h4>
+      <p><strong>Byte-Pair Encoding (BPE)</strong> splits text into subword tokens. Starting from individual bytes, it iteratively merges the most frequent adjacent pair until a target vocabulary size is reached (typically 32K&#8211;100K tokens). Two major implementations:</p>
+      <ul>
+        <li><strong><a href="https://github.com/openai/tiktoken">tiktoken</a></strong> (OpenAI): Used by GPT-3.5, GPT-4, o1. ~100K vocabulary. Operates on UTF-8 bytes.</li>
+        <li><strong><a href="https://github.com/google/sentencepiece">SentencePiece</a></strong> (Google/Meta): Used by LLaMA, Gemma, T5. Unigram or BPE mode. Operates on Unicode codepoints.</li>
+      </ul>
+      <p>Before tokenization, <strong>NFKC normalization</strong> (Unicode Normalization Form KC) maps compatibility-equivalent characters to their canonical form: fullwidth Latin &#8220;&#xFF21;&#8221; &#8594; &#8220;A&#8221;, math bold &#8220;&#x1D400;&#8221; &#8594; &#8220;A&#8221;, superscript &#8220;&#178;&#8221; &#8594; &#8220;2&#8221;. Critically, NFKC does <strong>not</strong> map across scripts: Cyrillic &#8220;&#1072;&#8221; (U+0430) stays Cyrillic, not Latin &#8220;a&#8221; (U+0061). This means Cyrillic and Greek homoglyphs get distinct BPE tokens from their Latin lookalikes.</p>
+
+      <div class="callout callout-red">
+        <strong>The critical bottleneck is text extraction, not tokenization.</strong>
+        Trafilatura's <code>str.isprintable()</code> filter strips all format characters at Stage 2. Everything that passes extraction is faithfully preserved through quality filtering, dedup, and tokenization. Cross-script homoglyphs (Cyrillic, Greek) survive the entire pipeline end-to-end: they are printable, pass NFKC, and get distinct BPE tokens. This is the basis for Proposal 1.
+      </div>
     </div>
   </div>
 

--- a/docs/study/deep-dive/index.html
+++ b/docs/study/deep-dive/index.html
@@ -3489,6 +3489,119 @@ Knowledge graph builder (Google, Perplexity):
   </ul>
   <p>Chart: difference-in-differences plot with confidence intervals. Green zone: delta within +/- 0.1%. Red zone: delta exceeding threshold.</p>
 
+  <h3>Detection &amp; Measurement Plan</h3>
+  <p>Injection is half the system. The other half is: how do you find your markers once they're in the wild? Each proposal has a different detection timeline, detection method, and scale requirement.</p>
+
+  <h4>Detection Timeline by Channel</h4>
+  <p>The gap between injection and detection depends on <em>how</em> the scraped data is used. Three channels, three timelines:</p>
+  <div class="table-wrapper">
+  <table class="data-table">
+    <thead><tr><th>Channel</th><th>Time to Detection</th><th>What Triggers It</th><th>Which Proposals</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Direct scraping / RAG</strong></td><td>Hours to days</td><td>Scraped text appears in retrieval-augmented answers (Perplexity, ChatGPT Browse, Gemini). Canary names surface when users query for people in a given field.</td><td>P1, P2, P3, P5</td></tr>
+      <tr><td><strong>Third-party aggregation</strong></td><td>Days to weeks</td><td>Data broker databases (Apollo.io, ZoomInfo) ingest scraped profiles. Canary names appear in enrichment API responses or exposed databases.</td><td>P3 (primary)</td></tr>
+      <tr><td><strong>LLM training</strong></td><td>Weeks to months</td><td>Next training run ingests scraped data. Canary names become part of model knowledge. Homoglyph patterns alter token distributions. Detectable via probing queries and statistical tests.</td><td>P1 (primary), P3</td></tr>
+    </tbody>
+  </table>
+  </div>
+  <div class="callout callout-gold">
+    <strong>Implication</strong>
+    Don't wait for training-time detection. The RAG channel gives results in days. Start probing Perplexity and ChatGPT Browse within 48 hours of canary deployment. Training-time detection is the long game &mdash; it confirms the watermarks survived the full pipeline, but the immediate signal comes from RAG and aggregator channels.
+  </div>
+
+  <h4>Scale: How Many Canaries and Watermarks?</h4>
+  <div class="table-wrapper">
+  <table class="data-table">
+    <thead><tr><th>Parameter</th><th>Value</th><th>Rationale</th></tr></thead>
+    <tbody>
+      <tr><td><strong>Canary names/day</strong></td><td>~50K&ndash;200K unique</td><td>One per suspicious session (beacon-absent or tripwire-triggered). LinkedIn sees millions of profile views/day; 1&ndash;5% are likely scrapers, each getting a unique canary.</td></tr>
+      <tr><td><strong>Watermarked pages/day</strong></td><td>All treatment-group renders</td><td>At 50% treatment: millions/day. Each render gets a session-unique homoglyph pattern. No cap needed &mdash; the watermark is deterministic from session_id + secret.</td></tr>
+      <tr><td><strong>LLM probes/day</strong></td><td>~500&ndash;2,000</td><td>Sample from the past 7 days of canary names. Probe each against 5 models (GPT, Claude, Gemini, Perplexity, Grok). Budget: ~$2&ndash;5/day at current API pricing.</td></tr>
+      <tr><td><strong>Data broker checks/week</strong></td><td>~1,000</td><td>Query ZoomInfo, Pipl, Apollo enrichment APIs for canary names. Most return nothing; a hit is definitive proof of ingestion.</td></tr>
+      <tr><td><strong>Common Crawl scan/month</strong></td><td>Full monthly release</td><td>Grep the WARC files for canary names. Common Crawl publishes monthly. A canary name in CC proves it propagated beyond the original scraper.</td></tr>
+    </tbody>
+  </table>
+  </div>
+
+  <h4>Detection Methods by Proposal</h4>
+
+  <div class="card">
+    <div class="card-header" onclick="toggleCard(this)">
+      <h3>P1 Homoglyphs: Statistical Token Distribution Test</h3>
+      <span class="card-toggle">&#9654;</span>
+    </div>
+    <div class="card-body">
+      <p><strong>What to look for:</strong> Elevated probability of Cyrillic/Greek token IDs at positions where Latin characters normally appear. If a model was trained on homoglyph-watermarked LinkedIn profiles, it will assign non-trivial probability to Cyrillic "е" (token ID X) in contexts where Latin "e" (token ID Y) is expected.</p>
+      <p><strong>Method:</strong> Use the model's logprobs API (available for GPT-4, Claude, Gemini). Generate completions for LinkedIn-style prompts ("Senior Software Engineer at..."). Compare the probability ratio P(Cyrillic token) / P(Latin token) against a baseline model that was not trained on watermarked data. A statistically significant elevation (p &lt; 0.01) indicates watermark contamination.</p>
+      <p><strong>Scale needed:</strong> Per Sander et al. (NeurIPS 2024), watermark detection achieves p &lt; 10<sup>-5</sup> at 5% training data contamination. LinkedIn profiles are a substantial fraction of professional-domain web text. If 50% of scraped LinkedIn renders carry homoglyph watermarks, and LinkedIn represents even 1% of a model's professional-text training data, the signal should be detectable.</p>
+      <p><strong>Timeline:</strong> Requires the next model training run to complete. For frontier models this is 1&ndash;4 months. For fine-tuned models or RAG indexes, detection is possible within days.</p>
+      <p><strong>Limitation:</strong> Requires logprobs API access. Some providers (Perplexity) don't expose logprobs. For those, fall back to canary name probing.</p>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header" onclick="toggleCard(this)">
+      <h3>P3 Canaries: Name-Based Probing</h3>
+      <span class="card-toggle">&#9654;</span>
+    </div>
+    <div class="card-body">
+      <p><strong>What to look for:</strong> An LLM that, when asked "Who is Meridian Castleford?", returns the canary's generated job title and employer name. A data broker API that returns a record for the canary name with LinkedIn-sourced metadata.</p>
+      <p><strong>Probe design:</strong></p>
+      <ol>
+        <li><strong>Direct query:</strong> "Who is [canary name]?" &mdash; if the model has memorized the canary, it will fabricate a confident biography using the injected details.</li>
+        <li><strong>Contextual query:</strong> "List people who work at [canary company]" &mdash; tests whether the canary entity was indexed as part of an organization graph.</li>
+        <li><strong>Completions probe:</strong> "[canary name] is a" &mdash; if the model completes with the injected job title, the canary was in training data.</li>
+        <li><strong>JSON-LD channel:</strong> Google Knowledge Panel search for canary name. If Google indexed the JSON-LD entity, it may appear in search results or knowledge cards.</li>
+      </ol>
+      <p><strong>False positive rate:</strong> Near zero. HMAC-derived names are pronounceable but nonexistent. "Meridian Castleford" has zero Google results before injection. Any model that knows about this person learned it from LinkedIn's SSR output.</p>
+      <p><strong>False negative rate:</strong> Higher. Models may have ingested the canary but refuse to output it (safety filters), or the memorization may be too weak to surface on a direct query. Mitigation: probe with multiple prompt formats, increase canary volume to improve statistical coverage.</p>
+      <p><strong>Attribution on hit:</strong> canary name &rarr; HMAC reverse lookup &rarr; session_id &rarr; session log &rarr; IP, user-agent, account, timestamp, TLS fingerprint. Full evidence chain for legal.</p>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-header" onclick="toggleCard(this)">
+      <h3>P6 Pipeline FP: Differential CSS Survival</h3>
+      <span class="card-toggle">&#9654;</span>
+    </div>
+    <div class="card-body">
+      <p><strong>What to look for:</strong> When a canary name is detected in external data, check <em>which</em> of the four CSS-layered canary names survived. Each layer uses a different CSS hiding method. The binary survival pattern (S/X for each layer) maps to an extraction tool.</p>
+      <p><strong>Survival matrix:</strong></p>
+      <div class="table-wrapper">
+      <table class="data-table" style="font-size:0.85em">
+        <thead><tr><th>CSS Method</th><th>Trafilatura</th><th>BS4</th><th>CC WET</th><th>Readability</th></tr></thead>
+        <tbody>
+          <tr><td><code>font-size:0</code></td><td class="cell-survive">S</td><td class="cell-survive">S</td><td class="cell-survive">S</td><td class="cell-survive">S</td></tr>
+          <tr><td><code>display:none</code></td><td class="cell-stripped">X</td><td class="cell-survive">S</td><td class="cell-stripped">X</td><td class="cell-stripped">X</td></tr>
+          <tr><td><code>visibility:hidden</code></td><td class="cell-survive">S</td><td class="cell-survive">S</td><td class="cell-survive">S</td><td class="cell-survive">S</td></tr>
+          <tr><td><code>clip:rect(0,0,0,0)</code></td><td class="cell-survive">S</td><td class="cell-survive">S</td><td class="cell-survive">S</td><td class="cell-survive">S</td></tr>
+        </tbody>
+      </table>
+      </div>
+      <p>If a canary appears with only layers 1, 3, 4 surviving (layer 2 stripped), the scraper used Trafilatura, CC WET, or Readability. If all 4 survive, it was BeautifulSoup or raw regex &mdash; a less sophisticated pipeline.</p>
+      <p><strong>Timeline:</strong> Same as canary detection. Pipeline fingerprinting is not a separate detection system; it piggybacks on canary hits.</p>
+    </div>
+  </div>
+
+  <h4>Measurement Infrastructure: What to Build</h4>
+  <ol>
+    <li><strong>Canary Log Store:</strong> Append-only table mapping (canary_name, session_id, timestamp, treatment_flags, css_layers). Indexed on canary_name for reverse lookup. Retention: 1 year minimum (legal evidence requires chain of custody).</li>
+    <li><strong>LLM Probe Runner:</strong> Daily cron. Reads canary log, samples ~500 names from past 7 days, queries 5 model APIs, parses responses for canary entity matches. Logs all results (including negatives). Alert on any positive hit.</li>
+    <li><strong>Data Broker Monitor:</strong> Weekly cron. Queries enrichment APIs (ZoomInfo, Apollo, Pipl) for canary names. Any non-empty response is a positive hit. Alert immediately.</li>
+    <li><strong>Common Crawl Scanner:</strong> Monthly. Download the latest CC WARC release. Grep for canary names. Match against canary log for attribution. Run on a batch cluster (the CC archive is petabytes).</li>
+    <li><strong>Logprobs Analyzer:</strong> Monthly. For models with logprobs APIs (GPT-4, Claude), run the statistical token distribution test for Cyrillic/Greek token elevation. Requires a clean baseline comparison (model without watermarked data in training).</li>
+    <li><strong>Alert Pipeline:</strong> Any positive detection feeds into a structured alert with: canary name, detection channel, detection timestamp, attributed session_id, session metadata, CSS layer survival pattern. This is the input to legal review.</li>
+  </ol>
+
+  <div class="callout callout-blue">
+    <strong>Expected timeline to first signal</strong>
+    <strong>Days 1&ndash;7:</strong> Tripwire and beacon metrics establish scraping baseline.<br>
+    <strong>Days 7&ndash;14:</strong> First canary probes against RAG systems (Perplexity, ChatGPT Browse). If any RAG system is actively scraping LinkedIn, canary hits are possible within 48 hours of ingestion.<br>
+    <strong>Days 14&ndash;30:</strong> Data broker checks may start returning canary names as scraped profiles enter aggregation pipelines.<br>
+    <strong>Months 1&ndash;4:</strong> Next major model training cycle completes. Logprobs test and canary probing against newly trained models. This is the long-term signal.<br>
+    <strong>Ongoing:</strong> Monthly Common Crawl scans catch canaries that propagated to the open web.
+  </div>
+
   <h3>Decision Points</h3>
   <p>Explicit go/no-go criteria at each phase boundary. No phase transition without data review.</p>
 


### PR DESCRIPTION
## Summary
- Add Common Crawl dataset table (C4, FineWeb, RefinedWeb, CCNet, The Pile, DCLM, RedPajama)
- Fix SVG pipeline diagram to show all 7 stages (was missing Language Detection)
- Add per-stage algorithm explanations: Trafilatura/isprintable, fastText lid.176, KenLM perplexity, MinHash/SimHash/LSH, BPE tokenization, NFKC normalization
- Each stage explains what it does, how it works, and why VENOM techniques survive or die at that stage

## Test plan
- [x] Local server: card expands, table renders, SVG shows 7 stages with arrows and annotations
- [x] Algorithm sections render with links (Trafilatura, fastText, KenLM, Jaccard similarity, Hamming distance, tiktoken, SentencePiece)
- [x] Red callout box renders at bottom
- [ ] Verify live deployment renders correctly